### PR TITLE
feat: Add limit and offset to query builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,4 @@ go.work.sum
 **/*.tar
 
 # vendor directory
-vendor/
 vendor

--- a/patch.go
+++ b/patch.go
@@ -68,6 +68,12 @@ type SQLPatch struct {
 	//
 	// This func should return true is the field is to be ignored
 	ignoreFieldsFunc IgnoreFieldsFunc
+
+	// limit is the limit for the SQL query
+	limit int
+
+	// offset is the offset for the SQL query
+	offset int
 }
 
 // newPatchDefaults creates a new SQLPatch with default options.
@@ -87,6 +93,8 @@ func newPatchDefaults(opts ...PatchOpt) *SQLPatch {
 		includeNilValues:  false,
 		ignoreFields:      nil,
 		ignoreFieldsFunc:  nil,
+		limit:             0,
+		offset:            0,
 	}
 
 	for _, opt := range opts {

--- a/patch_opts.go
+++ b/patch_opts.go
@@ -125,3 +125,17 @@ func WithIgnoredFieldsFunc(f IgnoreFieldsFunc) PatchOpt {
 		s.ignoreFieldsFunc = f
 	}
 }
+
+// WithLimit sets the limit for the SQL query.
+func WithLimit(limit int) PatchOpt {
+	return func(s *SQLPatch) {
+		s.limit = limit
+	}
+}
+
+// WithOffset sets the offset for the SQL query.
+func WithOffset(offset int) PatchOpt {
+	return func(s *SQLPatch) {
+		s.offset = offset
+	}
+}

--- a/sql.go
+++ b/sql.go
@@ -110,13 +110,21 @@ func (s *SQLPatch) GenerateSQL() (sqlStr string, args []any, err error) {
 	}
 
 	sqlBuilder.WriteString(strings.TrimSpace(where) + "\n")
-	sqlBuilder.WriteString(")")
+	sqlBuilder.WriteString(")\n")
+
+	if s.limit > 0 {
+		sqlBuilder.WriteString(fmt.Sprintf("LIMIT %d\n", s.limit))
+	}
+
+	if s.offset > 0 {
+		sqlBuilder.WriteString(fmt.Sprintf("OFFSET %d\n", s.offset))
+	}
 
 	sqlArgs := s.joinArgs
 	sqlArgs = append(sqlArgs, s.args...)
 	sqlArgs = append(sqlArgs, s.whereArgs...)
 
-	return sqlBuilder.String(), sqlArgs, nil
+	return strings.TrimSpace(sqlBuilder.String()), sqlArgs, nil
 }
 
 // PerformPatch executes the SQL update statement for the given resource.

--- a/sql_test.go
+++ b/sql_test.go
@@ -1490,6 +1490,85 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_IncludesZer
 	s.Equal([]any{73, "", nil, 1}, args)
 }
 
+func (s *generateSQLSuite) TestGenerateSQL_Success_WithLimit() {
+	type testObj struct {
+		Id   *int    `db:"id"`
+		Name *string `db:"name"`
+	}
+
+	obj := testObj{
+		Id:   ptr(1),
+		Name: ptr("test"),
+	}
+
+	mw := NewMockWherer(s.T())
+	mw.On("Where").Return("age = ?", []any{18})
+
+	sqlStr, args, err := GenerateSQL(obj,
+		WithTable("test_table"),
+		WithWhere(mw),
+		WithLimit(10),
+	)
+	s.Require().NoError(err)
+	s.Equal("UPDATE test_table\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)\nLIMIT 10", sqlStr)
+	s.Equal([]any{1, "test", 18}, args)
+
+	mw.AssertExpectations(s.T())
+}
+
+func (s *generateSQLSuite) TestGenerateSQL_Success_WithOffset() {
+	type testObj struct {
+		Id   *int    `db:"id"`
+		Name *string `db:"name"`
+	}
+
+	obj := testObj{
+		Id:   ptr(1),
+		Name: ptr("test"),
+	}
+
+	mw := NewMockWherer(s.T())
+	mw.On("Where").Return("age = ?", []any{18})
+
+	sqlStr, args, err := GenerateSQL(obj,
+		WithTable("test_table"),
+		WithWhere(mw),
+		WithOffset(10),
+	)
+	s.Require().NoError(err)
+	s.Equal("UPDATE test_table\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)\nOFFSET 10", sqlStr)
+	s.Equal([]any{1, "test", 18}, args)
+
+	mw.AssertExpectations(s.T())
+}
+
+func (s *generateSQLSuite) TestGenerateSQL_Success_WithLimitAndOffset() {
+	type testObj struct {
+		Id   *int    `db:"id"`
+		Name *string `db:"name"`
+	}
+
+	obj := testObj{
+		Id:   ptr(1),
+		Name: ptr("test"),
+	}
+
+	mw := NewMockWherer(s.T())
+	mw.On("Where").Return("age = ?", []any{18})
+
+	sqlStr, args, err := GenerateSQL(obj,
+		WithTable("test_table"),
+		WithWhere(mw),
+		WithLimit(10),
+		WithOffset(5),
+	)
+	s.Require().NoError(err)
+	s.Equal("UPDATE test_table\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)\nLIMIT 10\nOFFSET 5", sqlStr)
+	s.Equal([]any{1, "test", 18}, args)
+
+	mw.AssertExpectations(s.T())
+}
+
 type NewDiffSQLPatchSuite struct {
 	suite.Suite
 }


### PR DESCRIPTION
This change adds the ability to specify LIMIT and OFFSET clauses for the generated SQL queries.

The following changes are included:
- Added `WithLimit` and `WithOffset` options to `patch_opts.go`.
- Added `limit` and `offset` fields to the `SQLPatch` struct in `patch.go`.
- Modified `GenerateSQL` in `sql.go` to append `LIMIT` and `OFFSET` clauses to the SQL query.
- Added unit tests to `sql_test.go` to verify the new functionality.
